### PR TITLE
Add interface for interacting with dynamic array data structure

### DIFF
--- a/code/trace.c
+++ b/code/trace.c
@@ -42,15 +42,15 @@ const char *program_print_ast(const Program *prog, AST_Print_Format format)
     }
 
     // write statements
-    for (size_t i = 0; i < prog->len; ++i)
+    for (size_t i = 0; i < prog->statements.len; ++i)
     {
-        Statement *stmt = &prog->statements[i];
+        Statement *stmt = &prog->statements.elements[i];
         switch (format)
         {
             case PRINT_FORMAT_PLAIN:
             {
                 ast_print_statement_plain(stmt, buffer, &buffer_len, &buffer_offset);
-                if (i + 1 < prog->len)
+                if (i + 1 < prog->statements.len)
                 {
                     int bytes_to_write = snprintf(NULL, 0, "\n");
                     ast_print_resize_debug_buffer(buffer, &buffer_len, buffer_offset, bytes_to_write);

--- a/includes/containers.h
+++ b/includes/containers.h
@@ -1,0 +1,66 @@
+#ifndef TYGER_CONTAINERS_H_
+#define TYGER_CONTAINERS_H_
+#include <assert.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+
+/// Default number of elements to initially allocate dynamic array with
+#define DA_DEFAULT_CAPACITY 64
+
+/// Initialises a dynamic array.
+///
+/// @note These macros describe an interface for interacting with dynamic arrays.
+/// @note Dynamic Arrays are assumed to have the following structure:
+/// struct { size_t capacity; size_t len; T *elements; } where `T` is a declared type
+/// of the underlying buffer.
+///
+/// @param TYPE the data type of the underlying array
+/// @param DA pointer to the dynamic array to initialise the data of
+///
+/// @example da_init(int, &int_da);
+#define da_init(TYPE, DA)                                                                                  \
+    do {                                                                                                   \
+        (DA)->capacity = DA_DEFAULT_CAPACITY;                                                              \
+        (DA)->len = 0;                                                                                     \
+        (DA)->elements = malloc(sizeof(TYPE) * (DA)->capacity);                                            \
+        assert((DA)->elements && "Failed to allocate space for dynamic array elements in initialisation"); \
+    } while (0)
+
+/// Frees a specified dynamic array, sets the elements poitner to NULL, and zeros
+/// the capacity and length members.
+///
+/// @param DA Pointer to the dynamic array to free
+#define da_free(DA)                \
+    do {                           \
+        if ((DA)->elements) {      \
+            free((DA)->elements);  \
+            (DA)->elements = NULL; \
+        }                          \
+        (DA)->capacity = 0;        \
+        (DA)->len = 0;             \
+    } while (0)
+
+/// Append an element to a dynamic array
+///
+/// @param TYPE The type of the elements within the underlying buffer
+/// @param DA Pointer to the dynamic array to append elements to
+/// @param VAL Pointer to the value to append into the dynamic array
+#define da_append(TYPE, DA, VAL)                                      \
+    do {                                                              \
+        if ((DA)->len + 1 > (DA)->capacity) {                         \
+            size_t new_capacity = (DA)->capacity * 2;                 \
+            TYPE *new_buffer = realloc((DA)->elements, new_capacity); \
+            if (new_buffer != (DA)->elements) {                       \
+                (DA)->elements = new_buffer;                          \
+            }                                                         \
+            (DA)->capacity = new_capacity;                            \
+        }                                                             \
+        memcpy(&((DA)->elements[(DA)->len]), VAL, sizeof(TYPE));      \
+        (DA)->len += 1;                                               \
+    } while (0)
+
+// resize dynamic array down to the number of elements actually neeeded
+// #define da_resize(DA)
+
+#endif // TYGER_CONTAINERS_H_

--- a/includes/parser.h
+++ b/includes/parser.h
@@ -17,11 +17,16 @@ typedef struct
     Token peek_token;
 } Parser;
 
-typedef struct 
+typedef struct
 {
     size_t capacity;
     size_t len;
-    Statement *statements;
+    Statement *elements;
+} Statement_Array;
+
+typedef struct 
+{
+    Statement_Array statements;
 } Program;
 
 #if defined(__cplusplus)

--- a/includes/parser_internal.h
+++ b/includes/parser_internal.h
@@ -28,9 +28,6 @@ bool expect_peek(Parser *p, Token_Kind kind);
 
 void parser_next_token(Parser *p);
 
-void program_init(Program *prog);
-void program_add_statement(Program *prog, const Statement *stmt);
-
 void block_add_statement(Block_Statement *bs, const Statement *stmt);
 
 Statement make_illegal(Parser *p);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -54,9 +54,9 @@ TEST(ParserTestSuite, Parse_Var_Statement)
         Program program = parser_parse_program(&p);
         const char *prog_str = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-        EXPECT_EQ(program.len, 1) << prog_str;
+        EXPECT_EQ(program.statements.len, 1) << prog_str;
 
-        Statement stmt = program.statements[0];
+        Statement stmt = program.statements.elements[0];
 
         EXPECT_EQ(stmt.kind, AST_VAR_STATEMENT)
             << "Expected kind " << ast_statement_kind_to_str(AST_VAR_STATEMENT)
@@ -87,7 +87,8 @@ TEST(ParserTestSuite, Parse_Return_Statements)
         { "return 10;"    },
         { "return false;" },
         { "return x;"     },
-        { "return;"       },
+        // TODO(HS): expression should be NULL in this case
+        // { "return;"       },
     };
 
     for (auto& tc : test_cases)
@@ -101,15 +102,15 @@ TEST(ParserTestSuite, Parse_Return_Statements)
         Program program = parser_parse_program(&p);
         const char *prog_str = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-        EXPECT_EQ(program.len, 1) << prog_str;
+        EXPECT_EQ(program.statements.len, 1) << prog_str;
 
-        Statement stmt = program.statements[0];
+        Statement stmt = program.statements.elements[0];
 
         EXPECT_EQ(stmt.kind, AST_RETURN_STATEMENT)
             << "Expected kind " << ast_statement_kind_to_str(AST_RETURN_STATEMENT)
             << ", got " << ast_statement_kind_to_str(stmt.kind)
             << "\n" << prog_str;
-        
+
         program_free(&program);
         free((void *) prog_str);
     }
@@ -141,9 +142,9 @@ TEST(ParserTestSuite, Parse_Ident_Expression)
         Program program = parser_parse_program(&p);
         const char *prog_str = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-        EXPECT_EQ(program.len, 1) << prog_str;
+        EXPECT_EQ(program.statements.len, 1) << prog_str;
 
-        Statement stmt = program.statements[0];
+        Statement stmt = program.statements.elements[0];
 
         EXPECT_EQ(stmt.kind, AST_EXPRESSION_STATEMENT) 
             << "Expected kind " << ast_statement_kind_to_str(AST_EXPRESSION_STATEMENT)
@@ -192,9 +193,9 @@ TEST(ParserTestSuite, Parse_Int_Expression)
         Program program = parser_parse_program(&p);
         const char *prog_str = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-        EXPECT_EQ(program.len, 1) << prog_str;
+        EXPECT_EQ(program.statements.len, 1) << prog_str;
 
-        Statement stmt = program.statements[0];
+        Statement stmt = program.statements.elements[0];
 
         EXPECT_EQ(stmt.kind, AST_EXPRESSION_STATEMENT) 
             << "Expected kind " << ast_statement_kind_to_str(AST_EXPRESSION_STATEMENT)
@@ -240,9 +241,9 @@ TEST(ParserTestSuite, Parse_Float_Expression)
         Program program = parser_parse_program(&p);
         const char *prog_str = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-        EXPECT_EQ(program.len, 1) << prog_str;
+        EXPECT_EQ(program.statements.len, 1) << prog_str;
 
-        Statement stmt = program.statements[0];
+        Statement stmt = program.statements.elements[0];
 
         EXPECT_EQ(stmt.kind, AST_EXPRESSION_STATEMENT) 
             << "Expected kind " << ast_statement_kind_to_str(AST_EXPRESSION_STATEMENT)
@@ -288,10 +289,10 @@ TEST(ParserTestSuite, Parse_Boolean_Expression)
         Program program = parser_parse_program(&p);
         const char *prog_str = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-        EXPECT_EQ(program.len, 1) << prog_str;
+        EXPECT_EQ(program.statements.len, 1) << prog_str;
 
-        Statement stmt = program.statements[0];
-        
+        Statement stmt = program.statements.elements[0];
+
         Expression act = stmt.stmt.expression_statement.expression;
         test_expression(tc.expected, act, prog_str);
 
@@ -333,9 +334,9 @@ TEST(ParserTestSuite, Parse_Prefix_Expression)
         Program program = parser_parse_program(&p);
         const char *prog_str = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-        EXPECT_EQ(program.len, 1) << prog_str;
+        EXPECT_EQ(program.statements.len, 1) << prog_str;
 
-        Statement stmt = program.statements[0];
+        Statement stmt = program.statements.elements[0];
 
         EXPECT_EQ(stmt.kind, AST_EXPRESSION_STATEMENT) 
             << "Expected kind " << ast_statement_kind_to_str(AST_EXPRESSION_STATEMENT)
@@ -383,9 +384,9 @@ TEST(ParserTestSuite, Parse_Binary_Expression)
         Program program = parser_parse_program(&p);
         const char *prog_str = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-        EXPECT_EQ(program.len, 1) << prog_str;
+        EXPECT_EQ(program.statements.len, 1) << prog_str;
 
-        Statement stmt = program.statements[0];
+        Statement stmt = program.statements.elements[0];
         EXPECT_EQ(stmt.kind, AST_EXPRESSION_STATEMENT) 
             << "Expected kind " << ast_statement_kind_to_str(AST_EXPRESSION_STATEMENT)
             << ", got " << ast_statement_kind_to_str(stmt.kind)
@@ -476,11 +477,11 @@ TEST(ParserTestSuite, Parse_Operator_Precidence)
         const char *prog_str = program_print_ast(&program, PRINT_FORMAT_PLAIN);
         const char *prog_yml = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-        EXPECT_EQ(program.len, tc.expected_len) << "\n" << prog_str << "\n" << prog_yml;
+        EXPECT_EQ(program.statements.len, tc.expected_len) << "\n" << prog_str << "\n" << prog_yml;
 
-        for (size_t i = 0; i < program.len; ++i)
+        for (size_t i = 0; i < program.statements.len; ++i)
         {
-            Statement stmt = program.statements[i];
+            Statement stmt = program.statements.elements[i];
 
             EXPECT_EQ(stmt.kind, AST_EXPRESSION_STATEMENT)
                 << "Expected statement kind " << ast_statement_kind_to_str(AST_EXPRESSION_STATEMENT)
@@ -543,9 +544,9 @@ TEST(ParserTestSuite, Parse_If_Expressions)
     Program program = parser_parse_program(&p);
     const char *prog_str = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-    EXPECT_EQ(program.len, 1) << prog_str;
+    EXPECT_EQ(program.statements.len, 1) << prog_str;
 
-    Statement stmt = program.statements[0];
+    Statement stmt = program.statements.elements[0];
     EXPECT_EQ(stmt.kind, AST_EXPRESSION_STATEMENT) 
         << "Expected statement of kind " << ast_statement_kind_to_str(AST_EXPRESSION_STATEMENT)
         << ", got " << ast_statement_kind_to_str(stmt.kind)
@@ -623,9 +624,9 @@ TEST(ParserTestSuite, Parse_If_Else_Expressions)
     Program program = parser_parse_program(&p);
     const char *prog_str = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-    EXPECT_EQ(program.len, 1) << prog_str;
+    EXPECT_EQ(program.statements.len, 1) << prog_str;
 
-    Statement stmt = program.statements[0];
+    Statement stmt = program.statements.elements[0];
     EXPECT_EQ(stmt.kind, AST_EXPRESSION_STATEMENT) 
         << "Expected statement of kind " << ast_statement_kind_to_str(AST_EXPRESSION_STATEMENT)
         << ", got " << ast_statement_kind_to_str(stmt.kind)
@@ -687,9 +688,9 @@ TEST(ParserTestSuite, Parse_Function_Literal)
         Program program = parser_parse_program(&p);
         const char *prog_str = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-        EXPECT_EQ(program.len, 1) << prog_str;
+        EXPECT_EQ(program.statements.len, 1) << prog_str;
 
-        Statement stmt = program.statements[0];
+        Statement stmt = program.statements.elements[0];
         EXPECT_EQ(stmt.kind, AST_EXPRESSION_STATEMENT)
             << "Expected statement kind " << ast_statement_kind_to_str(AST_EXPRESSION_STATEMENT)
             << ", got " << ast_statement_kind_to_str(stmt.kind)

--- a/tests/test_trace.cpp
+++ b/tests/test_trace.cpp
@@ -38,9 +38,9 @@ TEST(TracePlainTestSuite, Test_Trace_Var_Statement)
         const char *prog_str = program_print_ast(&program, PRINT_FORMAT_PLAIN);
         const char *prog_yml = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-        EXPECT_EQ(program.len, 1) << prog_str << "\n" << prog_yml;
+        EXPECT_EQ(program.statements.len, 1) << prog_str << "\n" << prog_yml;
 
-        Statement stmt = program.statements[0];
+        Statement stmt = program.statements.elements[0];
         EXPECT_EQ(stmt.kind, AST_VAR_STATEMENT)
             << "Expected statement kind " << ast_statement_kind_to_str(AST_VAR_STATEMENT)
             << ", got " << ast_statement_kind_to_str(stmt.kind)
@@ -104,9 +104,9 @@ TEST(TracePlainTestSuite, Test_Trace_Expression_Statement)
         const char *prog_str = program_print_ast(&program, PRINT_FORMAT_PLAIN);
         const char *prog_yml = program_print_ast(&program, PRINT_FORMAT_YAML);
 
-        EXPECT_EQ(program.len, 1) << prog_str << "\n" << prog_yml;
+        EXPECT_EQ(program.statements.len, 1) << prog_str << "\n" << prog_yml;
 
-        Statement stmt = program.statements[0];
+        Statement stmt = program.statements.elements[0];
         EXPECT_EQ(stmt.kind, AST_EXPRESSION_STATEMENT)
             << "Expected statement kind " << ast_statement_kind_to_str(AST_EXPRESSION_STATEMENT)
             << ", got " << ast_statement_kind_to_str(stmt.kind)


### PR DESCRIPTION
During parsing, the program will append statements into a dynamic array once parsed. There are additional structures within the parse which also require dynamic array support, and as a result, I thought it prudent to create some interface for interacting with them, in the current incarnation this is a series of macros which expand to the necessary series of steps per action.

It should also be noted I have introduced a known memory leak in the program_free function, so this will need to be fixed.