### PR TITLE
refactor expression parsing to write to out params

### DIFF
--- a/code/parser.c
+++ b/code/parser.c
@@ -324,7 +324,7 @@ Expression parse_expression(Parser *p, Operator_Precidence precidence)
 
         case TK_LPAREN:
         {
-            expr = parse_grouped_expression(p);
+            parse_grouped_expression(p, &expr);
         } break;
 
         case TK_IF:
@@ -465,7 +465,7 @@ Expression parse_infix_expression(Parser *p, Expression *lhs)
     return expr;
 }
 
-Expression parse_grouped_expression(Parser *p)
+void parse_grouped_expression(Parser *p, Expression *grouped_expr)
 {
     parser_next_token(p);
     
@@ -474,7 +474,7 @@ Expression parse_grouped_expression(Parser *p)
     assert(peek_token_is(p, TK_RPAREN) && "Peeked token is not RParen");
     parser_next_token(p);
 
-    return expr;
+    memcpy(grouped_expr, &expr, sizeof(Expression));
 }
 
 void parse_if_expression(Parser *p, Expression *if_expr)

--- a/code/parser.c
+++ b/code/parser.c
@@ -319,7 +319,7 @@ Expression parse_expression(Parser *p, Operator_Precidence precidence)
         case TK_BANG:
         {
             expr.kind = AST_PREFIX_EXPRESSION;
-            expr.expr.prefix_expression = parse_prefix_expression(p);
+            parse_prefix_expression(p, &expr);
         } break;
 
         case TK_LPAREN:
@@ -411,21 +411,20 @@ void parse_boolean(Parser *p, Expression *bool_expr)
 
 // TODO(HS): better allocation strategy for expressions
 // TODO(HS): parse prefix op for idents (& call expr?)
-Prefix_Expression parse_prefix_expression(Parser *p)
+void parse_prefix_expression(Parser *p, Expression *prefix_expr)
 {
     Token op = p->cur_token;
-    Prefix_Expression expr = {0};
 
     switch (op.kind)
     {
         case TK_MINUS:
         {
-            expr.op = '-';
+            prefix_expr->expr.prefix_expression.op = '-';
         } break;
 
         case TK_BANG:
         {
-            expr.op = '!';
+            prefix_expr->expr.prefix_expression.op = '!';
         } break;
 
         default:
@@ -437,11 +436,9 @@ Prefix_Expression parse_prefix_expression(Parser *p)
     parser_next_token(p);
     Expression rhs = parse_expression(p, PREFIX);
 
-    expr.rhs = malloc(sizeof(Expression));
-    assert(expr.rhs && "Failed to allocate memory for expression");
-    memcpy(expr.rhs, &rhs, sizeof(Expression));
-
-    return expr;
+    prefix_expr->expr.prefix_expression.rhs = malloc(sizeof(Expression));
+    assert(prefix_expr->expr.prefix_expression.rhs && "Failed to allocate memory for expression");
+    memcpy(prefix_expr->expr.prefix_expression.rhs, &rhs, sizeof(Expression));
 }
 
 Expression parse_infix_expression(Parser *p, Expression *lhs)

--- a/code/parser.c
+++ b/code/parser.c
@@ -305,9 +305,9 @@ Expression parse_expression(Parser *p, Operator_Precidence precidence)
         case TK_FLOAT_LIT:
         {
             expr.kind = AST_FLOAT_EXPRESSION;
-            expr.expr.float_expression = parse_float(p);
+            parse_float(p, &expr);
         } break;
-        
+
         case TK_MINUS:
         case TK_BANG:
         {
@@ -384,7 +384,7 @@ void parse_int(Parser *p, Expression *int_expr)
     };
 }
 
-Float_Expression parse_float(Parser *p)
+void parse_float(Parser *p, Expression *float_expr)
 {
     // TODO(HS): handle integers which are too long string wise
     size_t slen = p->cur_token.literal.length;
@@ -397,10 +397,9 @@ Float_Expression parse_float(Parser *p)
     float val = (float) atof(buffer);
     free(buffer);
 
-    Float_Expression fexpr = {
+    float_expr->expr.float_expression = (Float_Expression) {
         .value = val
     };
-    return fexpr;
 }
 
 Boolean_Expression parse_boolean(Parser *p)

--- a/code/parser.c
+++ b/code/parser.c
@@ -308,18 +308,18 @@ Expression parse_expression(Parser *p, Operator_Precidence precidence)
             parse_float(p, &expr);
         } break;
 
+        case TK_FALSE:
+        case TK_TRUE:
+        {
+            expr.kind = AST_BOOLEAN_EXPRESSION;
+            parse_boolean(p, &expr);
+        } break;
+
         case TK_MINUS:
         case TK_BANG:
         {
             expr.kind = AST_PREFIX_EXPRESSION;
             expr.expr.prefix_expression = parse_prefix_expression(p);
-        } break;
-
-        case TK_FALSE:
-        case TK_TRUE:
-        {
-            expr.kind = AST_BOOLEAN_EXPRESSION;
-            expr.expr.boolean_expression = parse_boolean(p);
         } break;
 
         case TK_LPAREN:
@@ -402,12 +402,11 @@ void parse_float(Parser *p, Expression *float_expr)
     };
 }
 
-Boolean_Expression parse_boolean(Parser *p)
+void parse_boolean(Parser *p, Expression *bool_expr)
 {
-    Boolean_Expression expr = {
+    bool_expr->expr.boolean_expression = (Boolean_Expression) {
         .value = p->cur_token.kind == TK_TRUE ? true : false
     };
-    return expr;
 }
 
 // TODO(HS): better allocation strategy for expressions

--- a/code/parser.c
+++ b/code/parser.c
@@ -299,7 +299,7 @@ Expression parse_expression(Parser *p, Operator_Precidence precidence)
         case TK_INT_LIT:
         {
             expr.kind = AST_INT_EXPRESSION;
-            expr.expr.int_expression = parse_int(p);
+            parse_int(p, &expr);
         } break;
 
         case TK_FLOAT_LIT:
@@ -366,7 +366,7 @@ void parse_ident(Parser *p, Expression *ident_expr)
     ident_expr->expr.ident_expression.ident = buffer;
 }
 
-Int_Expression parse_int(Parser *p)
+void parse_int(Parser *p, Expression *int_expr)
 {
     // TODO(HS): handle integers which are too long string wise
     size_t slen = p->cur_token.literal.length;
@@ -379,10 +379,9 @@ Int_Expression parse_int(Parser *p)
     int val = atoi(buffer);
     free(buffer);
 
-    Int_Expression iexpr = {
+    int_expr->expr.int_expression = (Int_Expression) {
         .value = val
     };
-    return iexpr;
 }
 
 Float_Expression parse_float(Parser *p)

--- a/code/parser.c
+++ b/code/parser.c
@@ -336,7 +336,7 @@ Expression parse_expression(Parser *p, Operator_Precidence precidence)
         case TK_FUNC:
         {
             expr.kind = AST_FUNCTION_EXPRESSION;
-            expr.expr.function_expression = parse_function(p);
+            parse_function(p, &expr);
         } break;
 
         default:
@@ -628,23 +628,19 @@ Parameters parse_function_parameters(Parser *p)
     return params;
 }
 
-Function_Expression parse_function(Parser *p)
+void parse_function(Parser *p, Expression *func_expr)
 {
-    Function_Expression fexpr;
-
     // TODO(HS): errors
     if (!expect_peek(p, TK_LPAREN))
     {}
 
-    fexpr.parameters = parse_function_parameters(p);
+    func_expr->expr.function_expression.parameters = parse_function_parameters(p);
 
     // TODO(HS): errors
     if (!expect_peek(p, TK_LBRACE))
     {}
 
     Block_Statement bs = parse_block_statement(p);
-    fexpr.body = malloc(sizeof(Block_Statement));
-    memcpy(fexpr.body, &bs, sizeof(Block_Statement));
-
-    return fexpr;
+    func_expr->expr.function_expression.body = malloc(sizeof(Block_Statement));
+    memcpy(func_expr->expr.function_expression.body, &bs, sizeof(Block_Statement));
 }

--- a/code/parser.c
+++ b/code/parser.c
@@ -293,7 +293,7 @@ Expression parse_expression(Parser *p, Operator_Precidence precidence)
         case TK_IDENT:
         {
             expr.kind = AST_IDENT_EXPRESSION;
-            expr.expr.ident_expression = parse_ident(p);
+            parse_ident(p, &expr);
         } break;
 
         case TK_INT_LIT:
@@ -357,18 +357,13 @@ Expression parse_expression(Parser *p, Operator_Precidence precidence)
 
 // TODO(HS): better mem allocs
 // TODO(HS): free ident
-Ident_Expression parse_ident(Parser *p)
+void parse_ident(Parser *p, Expression *ident_expr)
 {
     size_t slen = p->cur_token.literal.length;
     char *buffer = malloc(sizeof(char) * (slen + 1));
     strncpy(buffer, p->cur_token.literal.str, slen);
-    buffer[p->cur_token.literal.length] = '\0';
-
-    Ident_Expression expr = {
-        .ident = buffer
-    };
-
-    return expr;
+    buffer[slen] = '\0';
+    ident_expr->expr.ident_expression.ident = buffer;
 }
 
 Int_Expression parse_int(Parser *p)
@@ -596,8 +591,9 @@ Parameters parse_function_parameters(Parser *p)
     params.idents = malloc(sizeof(Ident_Expression) * params.capacity);
 
     // parse first ident
-    Ident_Expression ie = parse_ident(p);
-    memcpy(params.idents, &ie, sizeof(Ident_Expression));
+    Expression ident_expr;
+    parse_ident(p, &ident_expr);
+    memcpy(params.idents, &ident_expr.expr.ident_expression, sizeof(Ident_Expression));
     params.len += 1;
 
     // parse remaining idents
@@ -617,8 +613,8 @@ Parameters parse_function_parameters(Parser *p)
             params.capacity = new_capacity;
         }
 
-        ie = parse_ident(p);
-        memcpy(&params.idents[params.len], &ie, sizeof(Ident_Expression));
+        parse_ident(p, &ident_expr);
+        memcpy(&params.idents[params.len], &ident_expr.expr.ident_expression, sizeof(Ident_Expression));
         params.len += 1;
     }
 

--- a/code/parser.c
+++ b/code/parser.c
@@ -330,7 +330,7 @@ Expression parse_expression(Parser *p, Operator_Precidence precidence)
         case TK_IF:
         {
             expr.kind = AST_IF_EXPRESSION;
-            expr.expr.if_expression = parse_if_expression(p);
+            parse_if_expression(p, &expr);
         } break;
 
         case TK_FUNC:
@@ -477,9 +477,10 @@ Expression parse_grouped_expression(Parser *p)
     return expr;
 }
 
-If_Expression parse_if_expression(Parser *p)
+void parse_if_expression(Parser *p, Expression *if_expr)
 {
-    If_Expression expr = {
+    if_expr->expr.if_expression = (If_Expression) {
+        .condition = NULL,
         .consequence = NULL,
         .alternative = NULL
     };
@@ -503,13 +504,13 @@ If_Expression parse_if_expression(Parser *p)
 
     Block_Statement consequence = parse_block_statement(p);
 
-    expr.condition   = malloc(sizeof(Expression));
-    assert(expr.condition && "Failed to allocate IF expression condition");
-    memcpy(expr.condition, &condition, sizeof(Expression));
+    if_expr->expr.if_expression.condition = malloc(sizeof(Expression));
+    assert(if_expr->expr.if_expression.condition && "Failed to allocate IF expression condition");
+    memcpy(if_expr->expr.if_expression.condition, &condition, sizeof(Expression));
 
-    expr.consequence = malloc(sizeof(Block_Statement));
-    assert(expr.condition && "Failed to allocate IF expression consequence");
-    memcpy(expr.consequence, &consequence, sizeof(Block_Statement));
+    if_expr->expr.if_expression.consequence = malloc(sizeof(Block_Statement));
+    assert(if_expr->expr.if_expression.condition && "Failed to allocate IF expression consequence");
+    memcpy(if_expr->expr.if_expression.consequence, &consequence, sizeof(Block_Statement));
 
     Block_Statement alternative;
     if (peek_token_is(p, TK_ELSE))
@@ -522,12 +523,10 @@ If_Expression parse_if_expression(Parser *p)
 
         alternative = parse_block_statement(p);
 
-        expr.alternative = malloc(sizeof(Block_Statement));
-        assert(expr.condition && "Failed to allocate IF expression alternative");
-        memcpy(expr.alternative, &alternative, sizeof(Block_Statement));
+        if_expr->expr.if_expression.alternative = malloc(sizeof(Block_Statement));
+        assert(if_expr->expr.if_expression.condition && "Failed to allocate IF expression alternative");
+        memcpy(if_expr->expr.if_expression.alternative, &alternative, sizeof(Block_Statement));
     }
-
-    return expr;
 }
 
 Block_Statement parse_block_statement(Parser *p)

--- a/includes/ast.h
+++ b/includes/ast.h
@@ -80,6 +80,7 @@ typedef struct
     Block_Statement *alternative;
 } If_Expression;
 
+// TODO(HS): conform to dynamic array "interface"
 typedef struct
 {
     size_t len;

--- a/includes/parser_internal.h
+++ b/includes/parser_internal.h
@@ -39,7 +39,7 @@ Statement parse_expression_statement(Parser *p);
 
 Expression parse_expression(Parser *p, Operator_Precidence precidence);
 
-Ident_Expression parse_ident(Parser *p);
+void parse_ident(Parser *p, Expression *ident_expr);
 Int_Expression parse_int(Parser *p);
 Float_Expression parse_float(Parser *p);
 Boolean_Expression parse_boolean(Parser *p);

--- a/includes/parser_internal.h
+++ b/includes/parser_internal.h
@@ -44,7 +44,7 @@ void parse_int(Parser *p, Expression *int_expr);
 void parse_float(Parser *p, Expression *float_expr);
 void parse_boolean(Parser *p, Expression *bool_expr);
 void parse_prefix_expression(Parser *p, Expression *prefix_expr);
-Expression parse_infix_expression(Parser *p, Expression *lhs);
+void parse_infix_expression(Parser *p, Expression *expr);
 void parse_grouped_expression(Parser *p, Expression *grouped_expr);
 void parse_if_expression(Parser *p, Expression *if_expr);
 Block_Statement parse_block_statement(Parser *p);

--- a/includes/parser_internal.h
+++ b/includes/parser_internal.h
@@ -46,7 +46,7 @@ void parse_boolean(Parser *p, Expression *bool_expr);
 void parse_prefix_expression(Parser *p, Expression *prefix_expr);
 Expression parse_infix_expression(Parser *p, Expression *lhs);
 Expression parse_grouped_expression(Parser *p);
-If_Expression parse_if_expression(Parser *p);
+void parse_if_expression(Parser *p, Expression *if_expr);
 Block_Statement parse_block_statement(Parser *p);
 Parameters parse_function_parameters(Parser *p);
 Function_Expression parse_function(Parser *p);

--- a/includes/parser_internal.h
+++ b/includes/parser_internal.h
@@ -40,7 +40,7 @@ Statement parse_expression_statement(Parser *p);
 Expression parse_expression(Parser *p, Operator_Precidence precidence);
 
 void parse_ident(Parser *p, Expression *ident_expr);
-Int_Expression parse_int(Parser *p);
+void parse_int(Parser *p, Expression *int_expr);
 Float_Expression parse_float(Parser *p);
 Boolean_Expression parse_boolean(Parser *p);
 Prefix_Expression parse_prefix_expression(Parser *p);

--- a/includes/parser_internal.h
+++ b/includes/parser_internal.h
@@ -45,7 +45,7 @@ void parse_float(Parser *p, Expression *float_expr);
 void parse_boolean(Parser *p, Expression *bool_expr);
 void parse_prefix_expression(Parser *p, Expression *prefix_expr);
 Expression parse_infix_expression(Parser *p, Expression *lhs);
-Expression parse_grouped_expression(Parser *p);
+void parse_grouped_expression(Parser *p, Expression *grouped_expr);
 void parse_if_expression(Parser *p, Expression *if_expr);
 Block_Statement parse_block_statement(Parser *p);
 Parameters parse_function_parameters(Parser *p);

--- a/includes/parser_internal.h
+++ b/includes/parser_internal.h
@@ -43,7 +43,7 @@ void parse_ident(Parser *p, Expression *ident_expr);
 void parse_int(Parser *p, Expression *int_expr);
 void parse_float(Parser *p, Expression *float_expr);
 void parse_boolean(Parser *p, Expression *bool_expr);
-Prefix_Expression parse_prefix_expression(Parser *p);
+void parse_prefix_expression(Parser *p, Expression *prefix_expr);
 Expression parse_infix_expression(Parser *p, Expression *lhs);
 Expression parse_grouped_expression(Parser *p);
 If_Expression parse_if_expression(Parser *p);

--- a/includes/parser_internal.h
+++ b/includes/parser_internal.h
@@ -49,6 +49,6 @@ Expression parse_grouped_expression(Parser *p);
 void parse_if_expression(Parser *p, Expression *if_expr);
 Block_Statement parse_block_statement(Parser *p);
 Parameters parse_function_parameters(Parser *p);
-Function_Expression parse_function(Parser *p);
+void parse_function(Parser *p, Expression *func_expr);
 
 #endif // TYGER_PARSER_INTERNAL_H_

--- a/includes/parser_internal.h
+++ b/includes/parser_internal.h
@@ -37,7 +37,7 @@ Statement parse_var_statement(Parser *p);
 Statement parse_return_statement(Parser *p);
 Statement parse_expression_statement(Parser *p);
 
-Expression parse_expression(Parser *p, Operator_Precidence precidence);
+void parse_expression(Parser *p, Expression *expr, Operator_Precidence precidence);
 
 void parse_ident(Parser *p, Expression *ident_expr);
 void parse_int(Parser *p, Expression *int_expr);

--- a/includes/parser_internal.h
+++ b/includes/parser_internal.h
@@ -42,7 +42,7 @@ Expression parse_expression(Parser *p, Operator_Precidence precidence);
 void parse_ident(Parser *p, Expression *ident_expr);
 void parse_int(Parser *p, Expression *int_expr);
 void parse_float(Parser *p, Expression *float_expr);
-Boolean_Expression parse_boolean(Parser *p);
+void parse_boolean(Parser *p, Expression *bool_expr);
 Prefix_Expression parse_prefix_expression(Parser *p);
 Expression parse_infix_expression(Parser *p, Expression *lhs);
 Expression parse_grouped_expression(Parser *p);

--- a/includes/parser_internal.h
+++ b/includes/parser_internal.h
@@ -41,7 +41,7 @@ Expression parse_expression(Parser *p, Operator_Precidence precidence);
 
 void parse_ident(Parser *p, Expression *ident_expr);
 void parse_int(Parser *p, Expression *int_expr);
-Float_Expression parse_float(Parser *p);
+void parse_float(Parser *p, Expression *float_expr);
 Boolean_Expression parse_boolean(Parser *p);
 Prefix_Expression parse_prefix_expression(Parser *p);
 Expression parse_infix_expression(Parser *p, Expression *lhs);

--- a/tests/parser_test_util.hpp
+++ b/tests/parser_test_util.hpp
@@ -42,7 +42,7 @@ void test_expression(Expression exp, Expression act, const char *prog_str)
 {
     EXPECT_EQ(exp.kind, act.kind)
         << "Expected expression of kind " << ast_expression_kind_to_str(exp.kind)
-        << ", got" << ast_expression_kind_to_str(act.kind)
+        << ", got " << ast_expression_kind_to_str(act.kind)
         << "\n" << prog_str;
 
     switch (exp.kind)

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -62,7 +62,7 @@ TEST(ParserTestSuite, Parse_Var_Statement)
             << "Expected kind " << ast_statement_kind_to_str(AST_VAR_STATEMENT)
             << ", got " << ast_statement_kind_to_str(stmt.kind)
             << "\n" << prog_str;
-        
+
         std::string expected_ident{tc.expected_ident};
         std::string actual_ident{stmt.stmt.var_statement.ident};
         EXPECT_EQ(expected_ident, actual_ident) << prog_str;
@@ -397,7 +397,7 @@ TEST(ParserTestSuite, Parse_Binary_Expression)
             << "Expected kind " << ast_expression_kind_to_str(AST_INFIX_EXPRESSION)
             << ", got " << ast_expression_kind_to_str(expr.kind)
             << "\n" << prog_str;
-        
+
         Infix_Expression inexpr = expr.expr.infix_expression;
 
         // test operator
@@ -408,17 +408,11 @@ TEST(ParserTestSuite, Parse_Binary_Expression)
 
         // test LHS
         Expression *lhs = inexpr.lhs;
-        EXPECT_EQ(lhs->kind, tc.lhs.kind)
-            << "Expected kind " << ast_expression_kind_to_str(tc.lhs.kind)
-            << ", got " << ast_expression_kind_to_str(lhs->kind)
-            << "\n" << prog_str;
+        test_expression(tc.lhs, *lhs, prog_str);
 
         // test RHS
         Expression *rhs = inexpr.rhs;
-        EXPECT_EQ(rhs->kind, tc.rhs.kind)
-            << "Expected kind " << ast_expression_kind_to_str(tc.rhs.kind)
-            << ", got " << ast_expression_kind_to_str(rhs->kind)
-            << "\n" << prog_str;
+        test_expression(tc.rhs, *rhs, prog_str);
 
         program_free(&program);
         free((void *) prog_str);


### PR DESCRIPTION
Parse `<blah>` expression functions now all write resultant expressions to out params.
Done in preparation for some more major refactoring of parser to handle errors.